### PR TITLE
Allow omitting front matter when generating Markdown posts

### DIFF
--- a/src/dump/generateFrontmatter.js
+++ b/src/dump/generateFrontmatter.js
@@ -1,18 +1,25 @@
 import serializeData from './serializeData';
 
 export default function generateFrontmatter(format, data) {
-  switch (format) {
-    case 'yaml':
-    case 'yml':
-      return `---\n${serializeData(format, data)}\n---\n\n`;
+  if (data) {
+    switch (format) {
+      case 'yaml':
+      case 'yml':
+        return `---\n${serializeData(format, data)}\n---\n\n`;
 
-    case 'toml':
-      return `+++\n${serializeData(format, data)}\n+++\n\n`;
+      case 'toml':
+        return `+++\n${serializeData(format, data)}\n+++\n\n`;
 
-    case 'json':
-      return `${serializeData(format, data)}\n\n`;
+      case 'json':
+        return `${serializeData(format, data)}\n\n`;
 
-    default:
-      throw new Error(`Unsupported format: ${format}`);
+      case 'md':
+        return '';
+
+      default:
+        throw new Error(`Unsupported format: ${format}`);
+    }
+  } else {
+    return '';
   }
 }


### PR DESCRIPTION
Add `md` format and return an empty string when generating frontmatter if `data` is null or if `md` format is specified. Fixes #4.