### PR TITLE
Fix: cannot read property 'agent' of undefined

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -4,7 +4,7 @@ import HttpsProxyAgent from 'https-proxy-agent';
 export default function fetchWithProxy(url, options) {
   const instanceOptions = Object.assign({}, options);
 
-  if (!options.agent && process.env.HTTPS_PROXY) {
+  if (!instanceOptions.agent && process.env.HTTPS_PROXY) {
     instanceOptions.agent = new HttpsProxyAgent(process.env.HTTPS_PROXY);
   }
 


### PR DESCRIPTION
Was receiving a `Type Error: cannot read property 'agent' of undefined` when using the client.uploadImage. 