### PR TITLE
Contentful Import improvements (drafts, etc)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -14,7 +14,7 @@ DatoCMS CLI tool
 Usage:
   dato dump [--watch] [--verbose] [--preview] [--token=<apiToken>] [--config=<file>]
   dato wp-import --token=<datoApiToken> --wpUrl=<url> --wpUser=<user> --wpPassword=<password>
-  dato contentful-import --datoCmsToken=<apiToken> --contentfulToken=<apiToken> --contentfulSpaceId=<spaceId>
+  dato contentful-import --datoCmsToken=<apiToken> --contentfulToken=<apiToken> --contentfulSpaceId=<spaceId> [--skipContent]
   dato check
   dato -h | --help
   dato --version
@@ -40,7 +40,8 @@ if (options.dump) {
     '--contentfulToken': contentfulToken,
     '--contentfulSpaceId': contentfulSpaceId,
     '--datoCmsToken': datoCmsToken,
+    '--skipContent': skipContent,
   } = options;
 
-  contentfulImport(contentfulToken, contentfulSpaceId, datoCmsToken);
+  contentfulImport(contentfulToken, contentfulSpaceId, datoCmsToken, skipContent);
 }

--- a/src/contentfulImport/command.js
+++ b/src/contentfulImport/command.js
@@ -10,11 +10,12 @@ import createRecords from './createRecords';
 import addValidationsOnField from './addValidationsOnField';
 import linkRecords from './linkRecords';
 import createUploads from './createUploads';
+import publishRecords from './publishRecords';
 
-export default async (contentfulToken, contentfulSpaceId, datoCmsToken) => {
+export default async (contentfulToken, contentfulSpaceId, datoCmsToken, skipContent) => {
   const client = await appClient(contentfulToken, contentfulSpaceId, datoCmsToken);
   const datoClient = client.dato;
-  const contentfulData = await getContentfulData(client.contentful);
+  const contentfulData = await getContentfulData(client.contentful, skipContent);
 
   await removeAllValidators({ datoClient, contentfulData });
 
@@ -28,29 +29,37 @@ export default async (contentfulToken, contentfulSpaceId, datoCmsToken) => {
 
   const fieldsMapping = await createFields({ itemTypes, datoClient, contentfulData });
 
-  const contentfulRecordMap = await createRecords({
-    itemTypes,
-    fieldsMapping,
-    datoClient,
-    contentfulData,
-  });
+  if (!skipContent) {
+    const contentfulRecordMap = await createRecords({
+      itemTypes,
+      fieldsMapping,
+      datoClient,
+      contentfulData,
+    });
 
-  await createUploads({
-    fieldsMapping,
-    itemTypes,
-    datoClient,
-    contentfulData,
-    contentfulRecordMap,
-  });
+    await createUploads({
+      fieldsMapping,
+      itemTypes,
+      datoClient,
+      contentfulData,
+      contentfulRecordMap,
+    });
+
+    await linkRecords({
+      fieldsMapping,
+      datoClient,
+      contentfulData,
+      contentfulRecordMap,
+    });
+
+    await publishRecords({
+      contentfulData,
+      contentfulRecordMap,
+      datoClient
+    });
+  }
 
   await addValidationsOnField({
     itemTypes, fieldsMapping, datoClient, contentfulData,
-  });
-
-  await linkRecords({
-    fieldsMapping,
-    datoClient,
-    contentfulData,
-    contentfulRecordMap,
   });
 };

--- a/src/contentfulImport/command.js
+++ b/src/contentfulImport/command.js
@@ -51,7 +51,7 @@ export default async (contentfulToken, contentfulSpaceId, datoCmsToken, skipCont
       datoClient,
     });
 
-    // ... and link records afterwards, to make it simple. If we link before 
+    // ... and link records afterwards, to make it simple. If we link before
     // wou would need to build a tree structure and publish in the correct order...
     const linkedRecords = await linkRecords({
       fieldsMapping,
@@ -60,7 +60,7 @@ export default async (contentfulToken, contentfulSpaceId, datoCmsToken, skipCont
       contentfulRecordMap,
     });
 
-    // ...but then we need to re-publish the records that 
+    // ...but then we need to re-publish the records that
     // had link fields set.
     await publishRecords({
       recordIds: linkedRecords,

--- a/src/contentfulImport/command.js
+++ b/src/contentfulImport/command.js
@@ -55,7 +55,7 @@ export default async (contentfulToken, contentfulSpaceId, datoCmsToken, skipCont
     await publishRecords({
       contentfulData,
       contentfulRecordMap,
-      datoClient
+      datoClient,
     });
   }
 

--- a/src/contentfulImport/command.js
+++ b/src/contentfulImport/command.js
@@ -30,7 +30,7 @@ export default async (contentfulToken, contentfulSpaceId, datoCmsToken, skipCont
   const fieldsMapping = await createFields({ itemTypes, datoClient, contentfulData });
 
   if (!skipContent) {
-    const contentfulRecordMap = await createRecords({
+    const { contentfulRecordMap, recordsToPublish } = await createRecords({
       itemTypes,
       fieldsMapping,
       datoClient,
@@ -45,16 +45,25 @@ export default async (contentfulToken, contentfulSpaceId, datoCmsToken, skipCont
       contentfulRecordMap,
     });
 
-    await linkRecords({
+    // publish all records that should be published...
+    await publishRecords({
+      recordIds: recordsToPublish,
+      datoClient,
+    });
+
+    // ... and link records afterwards, to make it simple. If we link before 
+    // wou would need to build a tree structure and publish in the correct order...
+    const linkedRecords = await linkRecords({
       fieldsMapping,
       datoClient,
       contentfulData,
       contentfulRecordMap,
     });
 
+    // ...but then we need to re-publish the records that 
+    // had link fields set.
     await publishRecords({
-      contentfulData,
-      contentfulRecordMap,
+      recordIds: linkedRecords,
       datoClient,
     });
   }

--- a/src/contentfulImport/createModels.js
+++ b/src/contentfulImport/createModels.js
@@ -25,7 +25,7 @@ export default async ({ datoClient, contentfulData }) => {
       sortable: false,
       tree: false,
       orderingField: null,
-      draftModeActive: false,
+      draftModeActive: true,
     };
 
     try {

--- a/src/contentfulImport/createRecords.js
+++ b/src/contentfulImport/createRecords.js
@@ -106,10 +106,6 @@ export default async ({
           itemType: itemType.id.toString(),
         });
 
-        if (entry.sys.publishedVersion) {
-          await datoClient.items.publish(record.id);
-        }
-
         spinner.text = progress.tick();
         contentfulRecordMap[entry.sys.id] = record.id;
       } catch (e) {

--- a/src/contentfulImport/createRecords.js
+++ b/src/contentfulImport/createRecords.js
@@ -106,6 +106,10 @@ export default async ({
           itemType: itemType.id.toString(),
         });
 
+        if (entry.sys.publishedVersion) {
+          await datoClient.items.publish(record.id);
+        }
+
         spinner.text = progress.tick();
         contentfulRecordMap[entry.sys.id] = record.id;
       } catch (e) {

--- a/src/contentfulImport/createRecords.js
+++ b/src/contentfulImport/createRecords.js
@@ -12,6 +12,7 @@ export default async ({
   const progress = new Progress(entries.length, 'Creating records');
 
   const contentfulRecordMap = {};
+  let recordsToPublish = [];
 
   spinner.text = progress.tick();
 
@@ -106,6 +107,10 @@ export default async ({
           itemType: itemType.id.toString(),
         });
 
+        if (entry.sys.publishedVersion) {
+          recordsToPublish.push(record.id);
+        }
+
         spinner.text = progress.tick();
         contentfulRecordMap[entry.sys.id] = record.id;
       } catch (e) {
@@ -125,5 +130,5 @@ export default async ({
 
   spinner.succeed();
 
-  return contentfulRecordMap;
+  return { contentfulRecordMap, recordsToPublish };
 };

--- a/src/contentfulImport/createRecords.js
+++ b/src/contentfulImport/createRecords.js
@@ -12,7 +12,7 @@ export default async ({
   const progress = new Progress(entries.length, 'Creating records');
 
   const contentfulRecordMap = {};
-  let recordsToPublish = [];
+  const recordsToPublish = [];
 
   spinner.text = progress.tick();
 

--- a/src/contentfulImport/getContentfulData.js
+++ b/src/contentfulImport/getContentfulData.js
@@ -1,6 +1,6 @@
 import ora from 'ora';
 
-export default async (client) => {
+export default async (client, skipContent) => {
   const spinner = ora('Downloading Contentful data structure').start();
   const environments = await client.getEnvironments();
   const environment = environments.items.find(e => e.name === 'master');
@@ -9,10 +9,18 @@ export default async (client) => {
   const locales = rawLocales.items.map(locale => locale.code);
   const rawContentTypes = await environment.getContentTypes();
   const contentTypes = rawContentTypes.items;
-  const rawEntries = await environment.getEntries();
-  const entries = rawEntries.items;
-  const rawAssets = await environment.getAssets();
-  const assets = rawAssets.items;
+
+  let entries;
+  let assets;
+
+  if (!skipContent) {
+    const rawEntries = await environment.getEntries();
+    const rawAssets = await environment.getAssets();
+
+    entries = rawEntries.items;
+    assets = rawAssets.items;
+  }
+
   spinner.succeed();
 
   return {

--- a/src/contentfulImport/linkRecords.js
+++ b/src/contentfulImport/linkRecords.js
@@ -13,7 +13,7 @@ export default async ({
   const spinner = ora('').start();
   const { entries, defaultLocale } = contentfulData;
   const progress = new Progress(entries.length, 'Linking records');
-  let recordsToPublish = [];
+  const recordsToPublish = [];
 
   spinner.text = progress.tick();
 
@@ -73,16 +73,13 @@ export default async ({
       });
     }, {});
 
-    // no links found, skip update.
-    if (Object.entries(recordAttributes).length === 0) {
-      spinner.text = progress.tick();
-      continue;
-    }
-
     try {
-      await datoClient.items.update(datoItemId, recordAttributes);
-      if (entry.sys.publishedVersion) {
-        recordsToPublish.push(datoItemId);
+      // if no links found, no update needed.
+      if (Object.entries(recordAttributes).length > 0) {
+        await datoClient.items.update(datoItemId, recordAttributes);
+        if (entry.sys.publishedVersion) {
+          recordsToPublish.push(datoItemId);
+        }
       }
       spinner.text = progress.tick();
     } catch (e) {

--- a/src/contentfulImport/linkRecords.js
+++ b/src/contentfulImport/linkRecords.js
@@ -13,6 +13,7 @@ export default async ({
   const spinner = ora('').start();
   const { entries, defaultLocale } = contentfulData;
   const progress = new Progress(entries.length, 'Linking records');
+  let recordsToPublish = [];
 
   spinner.text = progress.tick();
 
@@ -72,8 +73,17 @@ export default async ({
       });
     }, {});
 
+    // no links found, skip update.
+    if (Object.entries(recordAttributes).length === 0) {
+      spinner.text = progress.tick();
+      continue;
+    }
+
     try {
       await datoClient.items.update(datoItemId, recordAttributes);
+      if (entry.sys.publishedVersion) {
+        recordsToPublish.push(datoItemId);
+      }
       spinner.text = progress.tick();
     } catch (e) {
       spinner.fail(e);
@@ -83,4 +93,5 @@ export default async ({
     spinner.text = progress.tick();
   }
   spinner.succeed();
+  return recordsToPublish;
 };

--- a/src/contentfulImport/publishRecords.js
+++ b/src/contentfulImport/publishRecords.js
@@ -1,0 +1,26 @@
+import ora from 'ora';
+import Progress from './progress';
+
+export default async ({
+   contentfulData, contentfulRecordMap, datoClient
+}) => {
+    const spinner = ora('').start();
+    const { entries } = contentfulData;
+    const progress = new Progress(entries.length, 'Publishing records');
+
+    spinner.text = progress.tick();
+    for (const entry of entries) {
+        try {
+        if (entry.sys.publishedVersion) {
+            await datoClient.items.publish(contentfulRecordMap[entry.sys.id]);
+        }
+
+        spinner.text = progress.tick();
+        } catch (e) {
+            spinner.fail(e);
+            process.exit();
+        }
+    }
+
+    spinner.succeed();
+}

--- a/src/contentfulImport/publishRecords.js
+++ b/src/contentfulImport/publishRecords.js
@@ -2,25 +2,25 @@ import ora from 'ora';
 import Progress from './progress';
 
 export default async ({
-   contentfulData, contentfulRecordMap, datoClient
+  contentfulData, contentfulRecordMap, datoClient,
 }) => {
-    const spinner = ora('').start();
-    const { entries } = contentfulData;
-    const progress = new Progress(entries.length, 'Publishing records');
+  const spinner = ora('').start();
+  const { entries } = contentfulData;
+  const progress = new Progress(entries.length, 'Publishing records');
 
-    spinner.text = progress.tick();
-    for (const entry of entries) {
-        try {
-        if (entry.sys.publishedVersion) {
-            await datoClient.items.publish(contentfulRecordMap[entry.sys.id]);
-        }
+  spinner.text = progress.tick();
+  for (const entry of entries) {
+    try {
+      if (entry.sys.publishedVersion) {
+        await datoClient.items.publish(contentfulRecordMap[entry.sys.id]);
+      }
 
-        spinner.text = progress.tick();
-        } catch (e) {
-            spinner.fail(e);
-            process.exit();
-        }
+      spinner.text = progress.tick();
+    } catch (e) {
+      spinner.fail(e);
+      process.exit();
     }
+  }
 
-    spinner.succeed();
-}
+  spinner.succeed();
+};

--- a/src/contentfulImport/publishRecords.js
+++ b/src/contentfulImport/publishRecords.js
@@ -2,19 +2,15 @@ import ora from 'ora';
 import Progress from './progress';
 
 export default async ({
-  contentfulData, contentfulRecordMap, datoClient,
+  recordIds, datoClient,
 }) => {
   const spinner = ora('').start();
-  const { entries } = contentfulData;
-  const progress = new Progress(entries.length, 'Publishing records');
+  const progress = new Progress(recordIds.length, 'Publishing records');
 
   spinner.text = progress.tick();
-  for (const entry of entries) {
+  for (const recordId of recordIds) {
     try {
-      if (entry.sys.publishedVersion) {
-        await datoClient.items.publish(contentfulRecordMap[entry.sys.id]);
-      }
-
+      await datoClient.items.publish(recordId);
       spinner.text = progress.tick();
     } catch (e) {
       spinner.fail(e);


### PR DESCRIPTION
Hi,
Two changes;

1. Added a `--skipContent` flag to the contentful import that makes the import skip content and assets, but instead only creates the models.
 2. Since Contentful by default has a "publish/draft" system, it seems only logical that the imported models defaults to have that activated as well (In the previous code, entities not published in Contentful would be automatically published after an import to Dato). The importer now has a step last that publishes all the imported records that were published in Contentful. 