### PR TITLE
Catch errors on dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.5
+
+* Return 1 on `dato dump` errors, to allow better error handling inside CI processes or scripts.
+
 ## 1.0.0
 
 * Big rewrite, faster --watch mode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-client",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "DatoCMS API client and CLI tool",
   "browser": "dist/client.js",
   "main": "lib/index.js",

--- a/src/dump/command.js
+++ b/src/dump/command.js
@@ -25,40 +25,45 @@ export default async function (options) {
     process.exit(1);
   }
 
-  const client = new SiteClient(
-    token,
-    {
-      'X-Reason': 'dump',
-      'X-SSG': detectSsg(process.cwd()),
-    },
-    'https://site-api.datocms.com',
-  );
+  try {
+    const client = new SiteClient(
+      token,
+      {
+        'X-Reason': 'dump',
+        'X-SSG': detectSsg(process.cwd()),
+      },
+      'https://site-api.datocms.com',
+    );
 
-  const loader = new Loader(client, previewMode);
+    const loader = new Loader(client, previewMode);
 
-  process.stdout.write('Fetching content from DatoCMS');
-  await loader.load();
-  process.stdout.write('Done');
+    process.stdout.write('Fetching content from DatoCMS');
+    await loader.load();
+    process.stdout.write('Done');
 
-  await dump(configFile, new ItemsRepo(loader.entitiesRepo), quiet);
+    await dump(configFile, new ItemsRepo(loader.entitiesRepo), quiet);
 
-  if (watch) {
-    const unwatch = loader.watch(async (promise) => {
-      const watchSpinner = ora('Detected change in content, loading new data').start();
-      await promise;
-      watchSpinner.succeed();
-      return dump(configFile, new ItemsRepo(loader.entitiesRepo), quiet);
-    });
-
-    process.on('SIGINT', () => {
-      unwatch();
-      process.exit();
-    });
-
-    chokidar.watch(configFile)
-      .on('change', () => {
-        process.stdout.write('Detected change to config file!');
-        return dump(configFile, loader.itemsRepo, quiet);
+    if (watch) {
+      const unwatch = loader.watch(async (promise) => {
+        const watchSpinner = ora('Detected change in content, loading new data').start();
+        await promise;
+        watchSpinner.succeed();
+        return dump(configFile, new ItemsRepo(loader.entitiesRepo), quiet);
       });
+
+      process.on('SIGINT', () => {
+        unwatch();
+        process.exit();
+      });
+
+      chokidar.watch(configFile)
+        .on('change', () => {
+          process.stdout.write('Detected change to config file!');
+          return dump(configFile, loader.itemsRepo, quiet);
+        });
+    }
+  } catch (e) {
+    process.stderr.write(e.message);
+    process.exit(1);
   }
 }


### PR DESCRIPTION
Print the error message and return 1 to allow error catching on CI

To fix #33