### PR TITLE
Allow ~1GB files

### DIFF
--- a/src/upload/adapters/nodeLocal.js
+++ b/src/upload/adapters/nodeLocal.js
@@ -11,7 +11,7 @@ function uploadToS3(url, filePath) {
       'content-type': mime.lookup(filePath),
     },
     data: fs.readFileSync(filePath),
-    maxContentLength: 100000000,
+    maxContentLength: 1000000000,
   });
 }
 


### PR DESCRIPTION
I suggest bumping maxContentLength a bit further. Ideally the size should be that same as in the web ui, but I can seem to find any such limit.

1GB should be enough for our needs.