### PR TITLE
Make paginated fetches concurrent to speed up load for large sites

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@iarna/toml": "^2.2.3",
     "arr-diff": "^4.0.0",
     "axios": "^0.19.0",
+    "bottleneck": "^2.19.5",
     "chokidar": "^3.3.0",
     "clui": "^0.3.6",
     "colors": "^1.4.0",

--- a/src/Client.js
+++ b/src/Client.js
@@ -70,6 +70,8 @@ export default class Client {
 
     // console.log('---->', url, fullOptions);
 
+    // console.time(`fetch ${url}`);
+
     return fetch(url, fullOptions).then(res => {
       if (res.status === 429) {
         const waitTime = res.headers.get('X-RateLimit-Reset') || '10';
@@ -82,6 +84,7 @@ export default class Client {
       return (res.status !== 204 ? res.json() : Promise.resolve(null))
         .then(body => {
           if (res.status >= 200 && res.status < 300) {
+            // console.timeEnd(`fetch ${url}`);
             // console.log('<----', JSON.stringify(body));
             return Promise.resolve(body);
           }

--- a/src/Client.js
+++ b/src/Client.js
@@ -70,8 +70,6 @@ export default class Client {
 
     // console.log('---->', url, fullOptions);
 
-    // console.time(`fetch ${url}`);
-
     return fetch(url, fullOptions).then(res => {
       if (res.status === 429) {
         const waitTime = res.headers.get('X-RateLimit-Reset') || '10';
@@ -84,7 +82,6 @@ export default class Client {
       return (res.status !== 204 ? res.json() : Promise.resolve(null))
         .then(body => {
           if (res.status >= 200 && res.status < 300) {
-            // console.timeEnd(`fetch ${url}`);
             // console.log('<----', JSON.stringify(body));
             return Promise.resolve(body);
           }

--- a/src/utils/fetchAllPages.js
+++ b/src/utils/fetchAllPages.js
@@ -15,8 +15,6 @@ export default async function fetchAllPages(client, endpoint, params) {
 
   const totalCount = baseResponse.meta.total_count;
 
-  console.time(`fetchAllPages ${endpoint}`);
-
   const promises = [];
 
   for (
@@ -38,22 +36,13 @@ export default async function fetchAllPages(client, endpoint, params) {
 
   const data = await Promise.all(promises);
 
-  // console.log(`number of requests`, data.length);
-
-  console.timeEnd(`fetchAllPages ${endpoint}`);
-
   const result = data.reduce(
     (response, results) => {
-      // console.log(`count of results`, results.data.length);
       response.data = response.data.concat(results.data);
       return response;
     },
     { ...baseResponse },
   );
-
-  // console.log({
-  //   result,
-  // });
 
   return result;
 }

--- a/src/utils/fetchAllPages.js
+++ b/src/utils/fetchAllPages.js
@@ -1,31 +1,59 @@
-function times(n) {
-  /* eslint-disable prefer-spread */
-  return Array.apply(null, { length: n }).map(Number.call, Number);
-  /* eslint-enable prefer-spread */
-}
+import Bottleneck from 'bottleneck';
 
-export default function fetchAllPages(client, endpoint, params) {
-  const itemsPerPage = 100;
+const MAX_CONCURRENT = 10;
+const ITEMS_PER_PAGE = 500;
 
-  return client
-    .get(endpoint, { ...params, 'page[limit]': itemsPerPage })
-    .then(baseResponse => {
-      const pages = Math.ceil(baseResponse.meta.total_count / itemsPerPage);
+export default async function fetchAllPages(client, endpoint, params) {
+  const limiter = new Bottleneck({
+    maxConcurrent: MAX_CONCURRENT,
+  });
 
-      return times(pages - 1)
-        .reduce((chain, extraPage) => {
-          return chain.then(result => {
-            return client
-              .get(endpoint, {
-                ...params,
-                'page[offset]': itemsPerPage * (extraPage + 1),
-                'page[limit]': itemsPerPage,
-              })
-              .then(response => result.concat(response.data));
-          });
-        }, Promise.resolve(baseResponse.data))
-        .then(data => {
-          return { ...baseResponse, data };
+  const baseResponse = await client.get(endpoint, {
+    ...params,
+    'page[limit]': ITEMS_PER_PAGE,
+  });
+
+  const totalCount = baseResponse.meta.total_count;
+
+  console.time(`fetchAllPages ${endpoint}`);
+
+  const promises = [];
+
+  for (
+    let index = ITEMS_PER_PAGE;
+    index < totalCount;
+    index += ITEMS_PER_PAGE
+  ) {
+    promises.push(
+      limiter.schedule(async () => {
+        const response = await client.get(endpoint, {
+          ...params,
+          'page[offset]': index,
+          'page[limit]': ITEMS_PER_PAGE,
         });
-    });
+        return response;
+      }),
+    );
+  }
+
+  const data = await Promise.all(promises);
+
+  // console.log(`number of requests`, data.length);
+
+  console.timeEnd(`fetchAllPages ${endpoint}`);
+
+  const result = data.reduce(
+    (response, results) => {
+      // console.log(`count of results`, results.data.length);
+      response.data = response.data.concat(results.data);
+      return response;
+    },
+    { ...baseResponse },
+  );
+
+  // console.log({
+  //   result,
+  // });
+
+  return result;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1352,6 +1352,11 @@ boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bottleneck@^2.19.5:
+  version "2.19.5"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
+  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
+
 boxen@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-3.2.0.tgz#fbdff0de93636ab4450886b6ff45b92d098f45eb"


### PR DESCRIPTION
This PR bumps up concurrency and default batch size for paginated fetch requests leading to a massive speed bump. 

Our test site with a 100,000 records now loads in 20 seconds down from 30 minutes or so. 