### PR TITLE
added environment destroy command to CLI resolving #79

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -8,6 +8,7 @@ import contentfulImport from './contentfulImport/command';
 import toggleMaintenanceMode from './toggleMaintenanceMode/command';
 import createMigrationScript from './createMigrationScript/command';
 import runPendingMigrations from './runPendingMigrations/command';
+import destroyEnvironment from './destroyEnvironment/command';
 
 const doc = `
 DatoCMS CLI tool
@@ -16,6 +17,7 @@ Usage:
   dato dump [--watch] [--verbose] [--preview] [--token=<apiToken>] [--environment=<environment>] [--config=<file>]
   dato new migration <name> [--migrationsDir=<directory>]
   dato migrate [--source=<environment>] [--destination=<environment>] [--inPlace] [--migrationModel=<apiKey>] [--migrationsDir=<directory>] [--token=<apiToken>]
+  dato environment destroy <environmentId> [--token=<apiToken>]
   dato maintenance (on|off) [--force] [--token=<apiToken>]
   dato wp-import --token=<datoApiToken> [--environment=<datoEnvironment>] --wpUrl=<url> --wpUser=<user> --wpPassword=<password>
   dato contentful-import --datoCmsToken=<apiToken> --contentfulToken=<apiToken> --contentfulSpaceId=<spaceId> [--datoCmsEnvironment=<datoEnvironment>] [--skipContent] [(--includeOnly <contentType>...)]
@@ -71,6 +73,11 @@ Options:
       relativeMigrationsDir,
       token,
     });
+  }
+
+  if (options.maintenance) {
+    const { environmentId, '--token': token } = options;
+    return destroyEnvironment({ environmentId, token });
   }
 
   if (options['wp-import']) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -75,7 +75,7 @@ Options:
     });
   }
 
-  if (options.maintenance) {
+  if (options.environment && options.destroy) {
     const { environmentId, '--token': token } = options;
     return destroyEnvironment({ environmentId, token });
   }

--- a/src/destroyEnvironment/command.js
+++ b/src/destroyEnvironment/command.js
@@ -1,0 +1,13 @@
+import SiteClient from '../site/SiteClient';
+
+export default async function destroyEnvironment({
+  environmentId,
+  token: tokenByArg,
+}) {
+  const token = tokenByArg || process.env.DATO_MANAGEMENT_API_TOKEN;
+  const client = new SiteClient(token, {});
+
+  await client.environments.destroy(environmentId);
+
+  process.stdout.write(`Destroyed environment: ${environmentId}\n`);
+}


### PR DESCRIPTION
Added command to destroy sandbox environment.
Closes #79 

## How to test
```bash
dato new migration 'create article model'
dato migrate --destination=feature-add-article-model
dato environment destroy feature-add-article-model
```