### PR TITLE
Using correct format for destructuring environmentId from options

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -76,7 +76,7 @@ Options:
   }
 
   if (options.environment && options.destroy) {
-    const { environmentId, '--token': token } = options;
+    const { '<environmentId>': environmentId, '--token': token } = options;
     return destroyEnvironment({ environmentId, token });
   }
 


### PR DESCRIPTION
Closes #82

Previous PR #80 was using the CLI arguments in the wrong way see #82 for details.

## How to test
- Setup a project with sandboxes
- Create a sandbox called `destroy-my-env`

```bash
yarn lib &&./bin/dato.js environment destroy destroy-my-env
```