### PR TITLE
Updating TMP to prevent clobbering of SIGINT handlers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "rimraf": "^3.0.0",
         "speakingurl": "^14.0.1",
         "terser-webpack-plugin": "^1.4.2",
-        "tmp": "^0.1.0",
+        "tmp": "^0.2.1",
         "traverse": "^0.6.6",
         "truncate": "^2.1.0",
         "unist-util-visit": "^2.0.3",
@@ -12336,25 +12336,14 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
       "dependencies": {
-        "rimraf": "^2.6.3"
+        "rimraf": "^3.0.0"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tmp/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
+        "node": ">=8.17.0"
       }
     },
     "node_modules/to-arraybuffer": {
@@ -23933,21 +23922,11 @@
       }
     },
     "tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
       "requires": {
-        "rimraf": "^2.6.3"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
+        "rimraf": "^3.0.0"
       }
     },
     "to-arraybuffer": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "rimraf": "^3.0.0",
     "speakingurl": "^14.0.1",
     "terser-webpack-plugin": "^1.4.2",
-    "tmp": "^0.1.0",
+    "tmp": "^0.2.1",
     "traverse": "^0.6.6",
     "truncate": "^2.1.0",
     "unist-util-visit": "^2.0.3",


### PR DESCRIPTION
Currently binding to process.on("SIGINT", () => {}); is broken, due to the dependence on tmp v 0.1.0 (see https://github.com/raszi/node-tmp/issues/247).

This is prevents an importing app from gracefully shutting down a server as signal handling for SIGINT is not being being clobbered by tmp.

This PR updates TMP to the newest version.