### PR TITLE
bugfix: entries.length and assets.length undefined

### DIFF
--- a/src/contentfulImport/getContentfulData.js
+++ b/src/contentfulImport/getContentfulData.js
@@ -58,7 +58,8 @@ export default async ({
     assets = rawAssets;
   }
 
-  spinner.succeed(
+ spinner.succeed(
+    skipContent ? `Found ${contentTypes.length} content types, skipping content import` :
     `Found ${entries.length} entries and ${assets.length} assets in Contentful project`,
   );
 


### PR DESCRIPTION
When skipContent is true entries and assets are undefined. Trying to access entries.length and assets.length in the success message causes a typeError to be thrown.

I came up with a message I thought was suitable, but open to suggestions.