### PR TITLE
Replacing environment variable name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -170,6 +170,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/src/environment/destroy/command.js
+++ b/src/environment/destroy/command.js
@@ -9,7 +9,7 @@ export default async function command({
   const spinner = ora(
     `Destroying environment \`${environmentId}\`...\n`,
   ).start();
-  const token = tokenByArg || process.env.DATO_MANAGEMENT_API_TOKEN;
+  const token = tokenByArg || process.env.DATO_API_TOKEN;
   const client = new SiteClient(token, { baseUrl: cmaBaseUrl });
 
   try {

--- a/src/environment/getPrimary/command.js
+++ b/src/environment/getPrimary/command.js
@@ -1,7 +1,7 @@
 import SiteClient from '../../site/SiteClient';
 
 export default async function command({ token: tokenByArg, cmaBaseUrl }) {
-  const token = tokenByArg || process.env.DATO_MANAGEMENT_API_TOKEN;
+  const token = tokenByArg || process.env.DATO_API_TOKEN;
   const client = new SiteClient(token, { baseUrl: cmaBaseUrl });
 
   const allEnvs = await client.environments.all();

--- a/src/environment/promote/command.js
+++ b/src/environment/promote/command.js
@@ -10,7 +10,7 @@ export default async function command({
     `Promoting environment \`${environmentId}\` to primary environment\n`,
   ).start();
 
-  const token = tokenByArg || process.env.DATO_MANAGEMENT_API_TOKEN;
+  const token = tokenByArg || process.env.DATO_API_TOKEN;
   const client = new SiteClient(token, { baseUrl: cmaBaseUrl });
 
   try {

--- a/src/forkEnvironment/command.js
+++ b/src/forkEnvironment/command.js
@@ -7,7 +7,7 @@ export default async function runPendingMigrations({
   cmaBaseUrl,
   token: tokenByArg,
 }) {
-  const token = tokenByArg || process.env.DATO_MANAGEMENT_API_TOKEN;
+  const token = tokenByArg || process.env.DATO_API_TOKEN;
 
   const client = new SiteClient(token, { baseUrl: cmaBaseUrl });
   const allEnvironments = await client.environments.all();

--- a/src/runPendingMigrations/command.js
+++ b/src/runPendingMigrations/command.js
@@ -43,7 +43,7 @@ export default async function runPendingMigrations({
     .readdirSync(migrationsDir)
     .filter(file => file.match(MIGRATION_FILE_REGEXP));
 
-  const token = tokenByArg || process.env.DATO_MANAGEMENT_API_TOKEN;
+  const token = tokenByArg || process.env.DATO_API_TOKEN;
 
   const globalClient = new SiteClient(token, { baseUrl: cmaBaseUrl });
 

--- a/src/toggleMaintenanceMode/command.js
+++ b/src/toggleMaintenanceMode/command.js
@@ -7,7 +7,7 @@ export default async function toggleMaintenanceMode({
   force,
   cmaBaseUrl,
 }) {
-  const token = tokenByArg || process.env.DATO_MANAGEMENT_API_TOKEN;
+  const token = tokenByArg || process.env.DATO_API_TOKEN;
   const client = new SiteClient(token, { baseUrl: cmaBaseUrl });
 
   const { active } = await client.maintenanceMode.find();


### PR DESCRIPTION
As said in the issue #128  the token environment variable written by the dato check command is different than the one read by these commands on the client.